### PR TITLE
remove unnecssary execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+Version 0.2.1
+----------------------------
+* fixed unnecessary v8Executor.execute() in StethoHelper.bindV8ToChromeDebuggerIfReady() 
+
 Version 0.2.0
 ----------------------------
 * Updated V8 to 6.1.0

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ allprojects {
 Add dependency in *gradle.build* file of your app module
 ```gradle
 dependencies {
-    implementation ('com.github.AlexTrotsenko:j2v8-debugger:0.2.0') // {
+    implementation ('com.github.AlexTrotsenko:j2v8-debugger:0.2.1') // {
     //     optionally J2V8 can be excluded if specific version of j2v8 is needed or defined by other libs
     //     exclude group: 'com.eclipsesource.j2v8'
     // }

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 
 #publishing settings for Gradle build script
-VERSION_NAME=0.2.0
+VERSION_NAME=0.2.1
 #make group name of local build to be the same as by JitPack builds
 GROUP_NAME=com.github.AlexTrotsenko
 android.useAndroidX=true

--- a/j2v8-debugger/src/main/java/com/alexii/j2v8debugger/StethoHelper.kt
+++ b/j2v8-debugger/src/main/java/com/alexii/j2v8debugger/StethoHelper.kt
@@ -123,10 +123,10 @@ object StethoHelper {
     private fun bindV8ToChromeDebuggerIfReady() {
         val chromeDebuggerAttached = debugger != null && runtime != null
 
-        val v8Messenger = v8MessengerRef?.get()
-        val v8Executor = v8ExecutorRef?.get()
+        val v8Messenger = v8MessengerRef?.get() ?: return
+        val v8Executor = v8ExecutorRef?.get() ?: return
 
-        if (v8Messenger != null && v8Executor != null && chromeDebuggerAttached) {
+        if (chromeDebuggerAttached) {
                 bindV8DebuggerToChromeDebugger(
                     debugger!!,
                     runtime!!,

--- a/j2v8-debugger/src/main/java/com/alexii/j2v8debugger/StethoHelper.kt
+++ b/j2v8-debugger/src/main/java/com/alexii/j2v8debugger/StethoHelper.kt
@@ -121,19 +121,18 @@ object StethoHelper {
     }
 
     private fun bindV8ToChromeDebuggerIfReady() {
+        val v8Messenger = v8MessengerRef?.get()
+        val v8Executor = v8ExecutorRef?.get()
         val chromeDebuggerAttached = debugger != null && runtime != null
 
-        val v8Messenger = v8MessengerRef?.get() ?: return
-        val v8Executor = v8ExecutorRef?.get() ?: return
+        if (v8Messenger == null || v8Executor == null || !chromeDebuggerAttached) return
 
-        if (chromeDebuggerAttached) {
-                bindV8DebuggerToChromeDebugger(
-                    debugger!!,
-                    runtime!!,
-                    v8Executor,
-                    v8Messenger
-                )
-        }
+        bindV8DebuggerToChromeDebugger(
+            debugger!!,
+            runtime!!,
+            v8Executor,
+            v8Messenger
+        )
     }
 
     /**

--- a/j2v8-debugger/src/main/java/com/alexii/j2v8debugger/StethoHelper.kt
+++ b/j2v8-debugger/src/main/java/com/alexii/j2v8debugger/StethoHelper.kt
@@ -127,14 +127,12 @@ object StethoHelper {
         val v8Executor = v8ExecutorRef?.get()
 
         if (v8Messenger != null && v8Executor != null && chromeDebuggerAttached) {
-            v8Executor.execute {
                 bindV8DebuggerToChromeDebugger(
                     debugger!!,
                     runtime!!,
                     v8Executor,
                     v8Messenger
                 )
-            }
         }
     }
 


### PR DESCRIPTION
v8Executor.execute was unnecessary here as this is only setting references, not calling v8.  This was causing an issue depending on when bindV8ToChromeDebuggerIfReady was called.