### PR TITLE
Fix for setting breakpoints while debugger is paused.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+Version 0.2.2
+----------------------------
+* Setting breakpoints during debugging (paused) doesn't kill DevTools.  Next execution will pick up breakpoint.
+
 Version 0.2.1
 ----------------------------
 * fixed unnecessary v8Executor.execute() in StethoHelper.bindV8ToChromeDebuggerIfReady() 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,6 @@ Later v8 executor will be passed to Chrome DevTools and used for performing debu
 
 If Guava is already used in project - MoreExecutors and [ListenableFuture](https://github.com/google/guava/wiki/ListenableFutureExplained) could be handy.
 
-### Known issues
-- It's not possible to set break-point while debugging in progress.
-
- Reason: Since V8 thread is suspended - setting new breakpoint is not possible as it must run on the same V8 thread.
- 
 ### License
 
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ allprojects {
 Add dependency in *gradle.build* file of your app module
 ```gradle
 dependencies {
-    implementation ('com.github.AlexTrotsenko:j2v8-debugger:0.2.1') // {
+    implementation ('com.github.AlexTrotsenko:j2v8-debugger:0.2.2') // {
     //     optionally J2V8 can be excluded if specific version of j2v8 is needed or defined by other libs
     //     exclude group: 'com.eclipsesource.j2v8'
     // }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:3.6.3"
+        classpath "com.android.tools.build:gradle:4.0.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 
 #publishing settings for Gradle build script
-VERSION_NAME=0.2.1
+VERSION_NAME=0.2.2
 #make group name of local build to be the same as by JitPack builds
 GROUP_NAME=com.github.AlexTrotsenko
 android.useAndroidX=true

--- a/j2v8-debugger-sample/build.gradle
+++ b/j2v8-debugger-sample/build.gradle
@@ -27,7 +27,6 @@ android {
     dataBinding{
         enabled = true
     }
-
 }
 
 ext {


### PR DESCRIPTION
Changed add breakpoint function to execute instead of submit v8Executor call.  If debugger was running it never submitted.  Since the result doesn't rely on the the call we don't need to submit, we can just execute the v8Exector.

The newly added breakpoint will not be hit until the script is executed again, but it will no longer kill DevTools when a breakpoint is set while debugging.  Might be able to have it hit the breakpoint as well, but this is much better than before.