### PR TITLE
Fix CDT content are disordered

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven { url "https://jitpack.io" }
     }
     dependencies {
         classpath "com.android.tools.build:gradle:4.0.0"
@@ -25,6 +26,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven { url "https://jitpack.io" }
     }
 }
 

--- a/j2v8-debugger/build.gradle
+++ b/j2v8-debugger/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
     // J2V8 Runtime
     api("com.eclipsesource.j2v8:j2v8:6.1.0@aar")
-    api("com.facebook.stetho:stetho:1.5.1")
+    api("com.github.yinyinnie:stetho:v1.0.0")
 
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version")
     implementation("androidx.annotation:annotation:1.1.0")


### PR DESCRIPTION
Facebook official Stetho SDK have been stopping to maintain. So I create our own Stetho SDK repository and release aar to JitPack. github repository url: https://github.com/yinyinnie/stetho.

I have do test on latest Chrome. you can see my screenshot, as follows: 
![yy-j2v8-debugger](https://github.com/AlexTrotsenko/j2v8-debugger/assets/6081639/770b27fa-f0c1-4c9d-b262-0a033c177349)
